### PR TITLE
Try to fix the build

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -46,5 +46,13 @@
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
+    <dependency>
+      <groupId>eclipse</groupId>
+      <artifactId>org.eclipse.uml2.uml.profile.standard</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eclipse</groupId>
+      <artifactId>org.eclipse.uml2.types</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/model/src/main/ecore/sysml.ecore
+++ b/model/src/main/ecore/sysml.ecore
@@ -600,7 +600,7 @@
         <details key="documentation" value="A Copy relationship is a dependency between a supplier requirement and a client requirement that specifies that the text of the client requirement is a read-only copy of the text of the supplier requirement."/>
       </eAnnotations>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="Trace" eSuperTypes="#//blocks/DirectedRelationshipPropertyPath ../../../../../org.eclipse.uml2.uml.profile.standard/model/Standard.ecore#//Trace">
+    <eClassifiers xsi:type="ecore:EClass" name="Trace" eSuperTypes="#//blocks/DirectedRelationshipPropertyPath http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard#//Trace">
       <eOperations name="getTracedFrom" ordered="false" lowerBound="1">
         <eParameters name="ref" ordered="false" lowerBound="1" eType="ecore:EClass UML.ecore#//NamedElement"/>
         <eParameters name="result" ordered="false" upperBound="-1" eType="#//requirements/Requirement"/>
@@ -690,7 +690,7 @@
         <details key="documentation" value="&#xA;            A DeriveReqt relationship is a dependency between two requirements in which a client requirement can be derived from the supplier requirement. As with other dependencies, the arrow direction points from the derived (client) requirement to the (supplier) requirement from which it is derived.&#xA;          "/>
       </eAnnotations>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="Refine" eSuperTypes="#//blocks/DirectedRelationshipPropertyPath ../../../../../org.eclipse.uml2.uml.profile.standard/model/Standard.ecore#//Refine">
+    <eClassifiers xsi:type="ecore:EClass" name="Refine" eSuperTypes="#//blocks/DirectedRelationshipPropertyPath http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard#//Refine">
       <eOperations name="getRefines" ordered="false" lowerBound="1">
         <eParameters name="ref" ordered="false" lowerBound="1" eType="ecore:EClass UML.ecore#//NamedElement"/>
         <eParameters name="result" ordered="false" upperBound="-1" eType="#//requirements/Requirement"/>

--- a/model/src/main/ecore/sysml.genmodel
+++ b/model/src/main/ecore/sysml.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/tools.vitruv.methodologisttemplate.model/target/generated-sources/ecore"
     modelPluginID="tools.vitruv.methodologisttemplate.sysml" modelName="Sysml" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
-    usedGenPackages="../../../../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../../../../org.eclipse.uml2.uml.profile.standard/model/Standard.genmodel#//standard ../../../../../org.eclipse.uml2.types/model/Types.genmodel#//types"
+    usedGenPackages="platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore platform:/resource/org.eclipse.uml2.uml.profile.standard/model/Standard.genmodel#//standard platform:/resource/org.eclipse.uml2.types/model/Types.genmodel#//types"
     operationReflection="true" importOrganizing="true">
   <foreignModel>sysml.ecore</foreignModel>
   <genPackages prefix="Sysml" basePackage="tools.vitruv.methodologisttemplate" disposableProviderFactory="true"

--- a/model/workflow/generate.mwe2
+++ b/model/workflow/generate.mwe2
@@ -10,6 +10,19 @@ Workflow {
     bean = StandaloneSetup {
         scanClassPath = true
         platformUri = workspaceRoot
+
+        uriMap = {
+            from = "http://www.eclipse.org/emf/2002/Ecore"
+            to = "platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore"
+        }
+        uriMap = {
+            from = "http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard"
+            to = "platform:/resource/org.eclipse.uml2.uml.profile.standard/model/Standard.ecore"
+        }
+        uriMap = {
+            from = "http://www.eclipse.org/uml2/5.0.0/Types"
+            to = "platform:/resource/org.eclipse.uml2.types/model/Types.ecore"
+        }
     }
 
     component = EcoreGenerator {

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,31 @@
     <module>consistency</module>
   </modules>
 
+  <build>
+    <plugins>
+      <!-- allow Eclipse updatesites as repositories -->
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+        <version>1.9.0</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
   <properties>
     <vitruv.version>3.1.2</vitruv.version>
+    <repo.eclipse.version>2023-03</repo.eclipse.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>eclipse</id>
+      <name>Eclipse</name>
+      <layout>p2</layout>
+      <url>http://download.eclipse.org/releases/${repo.eclipse.version}</url>
+    </repository>
+  </repositories>
 
   <dependencyManagement>
     <dependencies>
@@ -92,6 +114,30 @@
         <artifactId>junit-jupiter</artifactId>
         <version>5.10.1</version>
       </dependency>
+
+      <!-- p2 dependencies -->
+      <dependency>
+        <groupId>eclipse</groupId>
+        <artifactId>org.eclipse.uml2.uml.profile.standard</artifactId>
+        <version>1.5.0.v20221116-1811</version>
+      </dependency>
+      <dependency>
+        <groupId>eclipse</groupId>
+        <artifactId>org.eclipse.uml2.types</artifactId>
+        <version>2.5.0.v20221116-1811</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <pluginRepositories>
+    <!-- required for the p2-layout-resolver plugin -->
+    <pluginRepository>
+      <id>artifactory.openntf.org</id>
+      <name>artifactory.openntf.org</name>
+      <url>https://artifactory.openntf.org/openntf</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 </project>


### PR DESCRIPTION
It doesn't work for now, but I started by adding the required Maven dependencies for the referenced meta-models and converting the relative URLs in the .ecore and .genmodel files, as described in the [build parent readme](https://github.com/vitruv-tools/Maven-Build-Parent#working-with-ecore-meta-models).